### PR TITLE
Updating README files with pointers to code mappings on EPIC UserWeb

### DIFF
--- a/etl-resources/README.md
+++ b/etl-resources/README.md
@@ -4,6 +4,15 @@ This folder will contain shared resources that are helpful for efforts attemptin
 
 Examples include:
 
-- Vocabulary mappings
+- Vocabulary mappings (see [Vendor-specific resources][#vendor-specific-resources])
 - Parsing code
 - Best practices
+
+## Vendor-specific resources
+
+Certain EHR vendors, such as EPIC, do not permit sharing of mappings files to non-EPIC users. As such, we are placing these mapping documents in vendor-specific locations (such as the Epic UserWeb).
+
+### EPIC
+
+* Kaleidoscope→OMOP concept mappings: [https://userweb.epic.com/Thread/128570/Kaleidoscope-to-OMOP-mappings/](https://userweb.epic.com/Thread/128570/Kaleidoscope-to-OMOP-mappings/)
+

--- a/etl-resources/iop/README.md
+++ b/etl-resources/iop/README.md
@@ -1,3 +1,7 @@
 # IOP
 
 This folder will contain resources related to extraction and validation of IOP data.
+
+## Mapping files
+
+* EPIC Kaleidoscope → OMOP concept mappings: [https://userweb.epic.com/Thread/128570/Kaleidoscope-to-OMOP-mappings/](https://userweb.epic.com/Thread/128570/Kaleidoscope-to-OMOP-mappings/)

--- a/etl-resources/visual-acuity/README.md
+++ b/etl-resources/visual-acuity/README.md
@@ -1,3 +1,11 @@
 # Visual Acuity
 
-For ETL parsing code, please see: [https://github.com/HribarLab/visualacuity](https://github.com/HribarLab/visualacuity).
+This folder will contain resources related to extraction and validation of visual acuity data.
+
+## Mapping files
+
+* EPIC Kaleidoscope → OMOP concept mappings: [https://userweb.epic.com/Thread/128570/Kaleidoscope-to-OMOP-mappings/](https://userweb.epic.com/Thread/128570/Kaleidoscope-to-OMOP-mappings/)
+
+## Data extraction and validation
+
+Work on visual acuity extraction / string parsing has been performed by Robert Gale and Michelle Hribar at OHSU, and is available at: [https://github.com/HribarLab/visualacuity](https://github.com/HribarLab/visualacuity).


### PR DESCRIPTION
We can't host the concept mappings directly on GitHub due to limitations on sharing imposed by EPIC. Therefore, hosting on the EPIC UserWeb and including links here.